### PR TITLE
Fix bad spliting in the derivation name

### DIFF
--- a/vinix/__main__.py
+++ b/vinix/__main__.py
@@ -24,7 +24,7 @@ def split_nix_derivation(store_path: str) -> str:
     if "-" in basename:
         splitted = basename.split("-")
         if len(splitted[0]) == 32:  # If its a store hash
-            return "-".join(basename.split("-"))[1:]
+            return "-".join(splitted[1:])
 
     return basename
 


### PR DESCRIPTION
I guess there is a misplaced parenthesis here:

https://github.com/adfaure/vinix/blob/2c421c592158221af534f9dbd6180a30e02f1e84/vinix/__main__.py#L27

you are just building back the name of the derivation, keeping all the but the first character :sweat_smile: 